### PR TITLE
Slack alerts when config test fails

### DIFF
--- a/lib/reload-nginx.js
+++ b/lib/reload-nginx.js
@@ -110,7 +110,7 @@ function generateNewConfig(configs) {
 
 function reloadNginxConfig(config) {
   fs.writeFileSync(configFileName, config);
-  const testCmd = process.env.NGINX_RELOAD === "false" ? "echo ()@" : "nginx -t";
+  const testCmd = process.env.NGINX_RELOAD === "false" ? "" : "nginx -t";
   const reloadCmd = process.env.NGINX_RELOAD === "false" ? "" : "service nginx reload";
   console.log("Testing new Nginx config...");
 

--- a/lib/reload-nginx.js
+++ b/lib/reload-nginx.js
@@ -1,3 +1,4 @@
+import axios from "axios";
 import checksum from "checksum";
 import fs from "fs";
 import { exec } from "child_process";
@@ -6,6 +7,7 @@ import { find } from "lodash";
 import nginxTemplate from "./nginx-template";
 import { api as dockerCloud } from "./docker-cloud";
 
+const { NGINX_LB_NAME: lbName, SLACK_WEBHOOK: slackWebhook } = process.env;
 const configFileName = process.env.NGINX_CONFIG_FILE || "/etc/nginx/conf.d/default.conf";
 const certsPath = process.env.NGINX_CERTS || "/certs";
 
@@ -44,7 +46,7 @@ function getLBServices(allContainers) {
   //find containers that have NGINX_SERVER_NAME env var
   allContainers.filter((container) => {
     return container.container_envvars
-      .filter(env => env.key === "NGINX_LB" && env.value === process.env.NGINX_LB_NAME)
+      .filter(env => env.key === "NGINX_LB" && env.value === lbName)
       .length
     ;
   })
@@ -108,18 +110,17 @@ function generateNewConfig(configs) {
 
 function reloadNginxConfig(config) {
   fs.writeFileSync(configFileName, config);
-  const testCmd = process.env.NGINX_RELOAD === "false" ? "" : "nginx -t";
+  const testCmd = process.env.NGINX_RELOAD === "false" ? "echo ()@" : "nginx -t";
   const reloadCmd = process.env.NGINX_RELOAD === "false" ? "" : "service nginx reload";
   console.log("Testing new Nginx config...");
 
   exec(testCmd, (error, stdout, stderr) => {
       if (error !== null) {
-        console.log('Nginx config error: ' + stderr);
-        console.log(config);
+        configFailed(config, stderr);
       } else {
         exec(reloadCmd, (error, stdout, stderr) => {
           if (error !== null) {
-            console.log('Nginx reload error: ' + stderr);
+            configFailed(config, stderr);
           } else {
             console.log('Nginx reload successful');
             console.log(config);
@@ -127,4 +128,20 @@ function reloadNginxConfig(config) {
         });
       }
   });
+}
+
+function configFailed(config, stderr) {
+  console.log("Config failed", stderr);
+  console.log(config);
+
+  if (slackWebhook) {
+    const text = `Nginx (${lbName}) config failed:
+*Error:*
+\`\`\`${stderr}\`\`\`
+*Config:*
+\`\`\`${config}\`\`\`
+    `;
+
+    axios.post(slackWebhook, {text, username: `Nginx ${lbName}`});
+  }
 }


### PR DESCRIPTION
When a config test fails, the LB needs to report a loud and clear message, so the bad config can be addressed before other apps redeploy.

- [x] offer slack webhook to ENV vars

This is a realistic problem scenario:
- appA deploys a bad config
- `nginx -t` fails, so the LB doesn't reload (keeps using last working config)
- appB redeploys and instances get new ip addresses
- LB still doesn't reload due to appA config being bad
- appB is now offline
