### PR TITLE
Increase client_max_body_size

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,7 @@ http {
   tcp_nodelay on;
   keepalive_timeout 65;
   types_hash_max_size 2048;
+  client_max_body_size 5m;
   # server_tokens off;
 
   # server_names_hash_bucket_size 64;


### PR DESCRIPTION
http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
Should be larger than default 1MB for now.