### PR TITLE
Automate SSL with Lets Encrypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 FROM ubuntu
 
-RUN apt-get update
-RUN apt-get install nginx curl -y
+RUN apt-get update && apt-get install -y \
+    nginx \
+    curl \
+    ca-certificates \
+    gcc \
+    libssl-dev \
+    libffi-dev \
+    python \
+    python-dev \
+    python-virtualenv
 RUN rm /etc/nginx/sites-enabled/default
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
@@ -25,6 +33,16 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc
+
+# fetch and untar latest simp_le client, clean up afterward
+RUN curl -SLO "https://github.com/kuba/simp_le/archive/master.tar.gz" \
+ && tar -xzf master.tar.gz -C /var \
+ && rm master.tar.gz \
+ && mv /var/simp_le-master /var/simp_le \
+ && mkdir -p /etc/ssl/letsencrypt
+
+# install simp_le virtualenv
+RUN (cd /var/simp_le && ./venv.sh)
 
 WORKDIR /app
 COPY ./package.json /app/package.json

--- a/lib/auto-ssl.js
+++ b/lib/auto-ssl.js
@@ -1,0 +1,44 @@
+import fs from "fs"
+import { spawnSync } from "child_process"
+
+export default function (host, email, linkDest) {
+  //where simp_le should create any keys, certs, etc
+  const sourceDest = `/etc/ssl/letsencrypt/${host}`;
+
+  //create sourceDest as necessary
+  try {
+    fs.accessSync(sourceDest);
+  } catch(e) {
+    fs.mkdirSync(sourceDest);
+  }
+
+  //try to generate cert via simp_le
+  let proc = null;
+  try {
+    proc = spawnSync("/var/simp_le/venv/bin/simp_le", [
+      "-d", host,
+      "--default_root", "/var/simp_le/webroot",
+      "-f", "account_key.json",
+      "-f", "full.pem",
+      "--email", email
+    ], { cwd: sourceDest, stdio: "inherit" });
+  } catch(err) {
+    console.log("Error calling simp_le:", err, err.stack);
+
+    return false;
+  }
+
+  //if cert was created (or already existed), symlink to linkDest and return success!
+  if (proc.status != 2) {
+    try {
+      fs.accessSync(linkDest);
+    } catch(e) {
+      console.log("Installing automated ssl for", host);
+      fs.symlinkSync(`${sourceDest}/full.pem`, linkDest);
+    }
+
+    return true;
+  }
+
+  return false;
+}

--- a/lib/docker-cloud-watch.js
+++ b/lib/docker-cloud-watch.js
@@ -1,4 +1,4 @@
-import reloadNginx from "./reload-nginx"
+import { reloadNginx } from "./reload-nginx"
 import { createStream } from "./docker-cloud"
 
 let interval

--- a/lib/nginx-template.js
+++ b/lib/nginx-template.js
@@ -10,6 +10,12 @@ server {
     ssl_certificate /certs/default.crt;
     ssl_certificate_key /certs/default.crt;
 
+    location ~ /\.well-known {
+        allow all;
+        root /var/simp_le/webroot;
+        try_files $uri $uri/ =404;
+    }
+
     return 404;
 }
 
@@ -25,6 +31,12 @@ server {
     listen 80;
 
     server_name {{host}};
+
+    location ~ /\.well-known {
+        allow all;
+        root /var/simp_le/webroot;
+        try_files $uri $uri/ =404;
+    }
 
     location / {
       proxy_pass http://{{upstreamName}};
@@ -49,6 +61,12 @@ server {
     ssl_ciphers                     ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
 
     add_header Strict-Transport-Security "max-age=31536000";
+
+    location ~ /\.well-known {
+        allow all;
+        root /var/simp_le/webroot;
+        try_files $uri $uri/ =404;
+    }
 
     location / {
       proxy_pass http://{{upstreamName}};

--- a/lib/nginx-template.js
+++ b/lib/nginx-template.js
@@ -10,7 +10,7 @@ server {
     ssl_certificate /certs/default.crt;
     ssl_certificate_key /certs/default.crt;
 
-    location ~ /\.well-known {
+    location /.well-known {
         allow all;
         root /var/simp_le/webroot;
         try_files $uri $uri/ =404;
@@ -32,7 +32,7 @@ server {
 
     server_name {{host}};
 
-    location ~ /\.well-known {
+    location /.well-known {
         allow all;
         root /var/simp_le/webroot;
         try_files $uri $uri/ =404;
@@ -62,7 +62,7 @@ server {
 
     add_header Strict-Transport-Security "max-age=31536000";
 
-    location ~ /\.well-known {
+    location /.well-known {
         allow all;
         root /var/simp_le/webroot;
         try_files $uri $uri/ =404;

--- a/lib/reload-nginx.js
+++ b/lib/reload-nginx.js
@@ -13,6 +13,9 @@ const configFileName = process.env.NGINX_CONFIG_FILE || "/etc/nginx/conf.d/defau
 const certsPath = process.env.NGINX_CERTS || "/certs"
 const containerLimit = process.env.CONTAINER_LIMIT || "25"
 
+let hasDeferredAutoSsl = false;
+let activeConfigExists = false;
+
 try {
   fs.mkdirSync(certsPath)
 } catch(e) {}
@@ -20,13 +23,21 @@ try {
 /*
  Sequence of Events
 */
-export default function() {
+export function reloadNginx() {
+  try {
+    fs.accessSync(configFileName);
+    activeConfigExists = true;
+  } catch(e) {
+    activeConfigExists = false;
+  }
+
   // list all containers
   dockerCloud(`/api/app/v1/container/?limit=${containerLimit}`)
     .then(fetchFullContainerDetail)
     .then(getContainersToBalance)
     .then(parseServices)
     .then(generateNewConfig)
+    .then(deferredAutoSsl)
     .catch(err => console.log("Error:", err, err.stack))
 }
 
@@ -83,9 +94,15 @@ export function parseServices(services) {
 
         //allow automatic ssl ONLY if we have an email to associate with
         if (autoSslEmail) {
-          //if no cert exists, try to create one via le (unless its explicitly skipped)
+          //if host has no existing cert AND autossl isnt explicitly skipped...
           if (!ssl && skipAutoSsl.indexOf(host) < 0) {
-            ssl = autoSsl(host, autoSslEmail, `${certsPath}/${host}.crt`)
+            //and if active nginx config, trigger automatic ssl
+            if (activeConfigExists) {
+              ssl = autoSsl(host, autoSslEmail, `${certsPath}/${host}.crt`)
+            //or if no active nginx config, defer autossl to next reload
+            } else {
+              hasDeferredAutoSsl = true;
+            }
           }
         }
 
@@ -129,6 +146,14 @@ export function generateNewConfig(configs) {
         console.log("Nginx config was unchanged");
       }
     });
+  }
+}
+
+export function deferredAutoSsl() {
+  if (hasDeferredAutoSsl) {
+    console.log("Running deferred automatic SSL");
+    hasDeferredAutoSsl = false;
+    reloadNginx();
   }
 }
 

--- a/lib/reload-nginx.js
+++ b/lib/reload-nginx.js
@@ -6,6 +6,7 @@ import { find, snakeCase, trim } from "lodash"
 
 import nginxTemplate from "./nginx-template"
 import { api as dockerCloud } from "./docker-cloud"
+import autoSsl from "./auto-ssl"
 
 const { NGINX_LB_NAME: lbName, SLACK_WEBHOOK: slackWebhook } = process.env
 const configFileName = process.env.NGINX_CONFIG_FILE || "/etc/nginx/conf.d/default.conf"
@@ -61,6 +62,12 @@ export function parseServices(services) {
     const allCerts = !certs ? [] : certs.value.split(",").map(val => val.split("\\n").join("\n"))
     const port = find(container.container_envvars, {key: "NGINX_PORT"})
 
+    let leEmail = find(container.container_envvars, {key: "NGINX_LE_EMAIL"})
+    const autoSslEmail = !leEmail ? false : leEmail.value;
+
+    let skipHosts = find(container.container_envvars, {key: "NGINX_LE_SKIP_HOST"})
+    const skipAutoSsl = !skipHosts ? [] : skipHosts.value.split(",")
+
     //for each virtual host, write a cert file if SSL exists,
     //and return {host, ssl}
     const virtualHosts = find(container.container_envvars, {key: "NGINX_VIRTUAL_HOST"}).value
@@ -72,6 +79,14 @@ export function parseServices(services) {
         if (allCerts[i] && allCerts[i].length) {
           fs.writeFileSync(`${certsPath}/${host}.crt`, allCerts[i])
           ssl = true
+        }
+
+        //allow automatic ssl ONLY if we have an email to associate with
+        if (autoSslEmail) {
+          //if no cert exists, try to create one via le (unless its explicitly skipped)
+          if (!ssl && skipAutoSsl.indexOf(host) < 0) {
+            ssl = autoSsl(host, autoSslEmail, `${certsPath}/${host}.crt`)
+          }
         }
 
         return { host: trim(host), upstreamName: snakeCase(host), ssl }


### PR DESCRIPTION
This implements automatic ssl cert generation for any domains in `NGINX_VIRTUAL_HOST` that (1) do not currently have a cert, and (2) are expected to be publicly accessible.
- using [simp_le client](https://github.com/kuba/simp_le)
- requires setting `NGINX_LE_EMAIL`, otherwise automatic ssl is skipped entirely. this is necessary to create an LE account with which the certs are associated
- accepts `NGINX_LE_SKIP_HOST`, for virtual hosts that should _never_ have ssl
- generates LE certs in `/etc/ssl/letsencrypt/${host}/` and symlinks to expected cert path

Issues of note:
- spawns the simp_le client with inherited stdio, which is useful for debugging. on the downside, it adds a LOT of extra output to the container logs
- ~~cert generation **always fails on first run**, since nginx has no config yet, and thus cannot serve the challenge response that LE requires. not sure how to resolve this chicken & egg problem~~
