### PR TITLE
[RFC] Scaling and Failover features

### DIFF
--- a/lib/nginx-template.js
+++ b/lib/nginx-template.js
@@ -10,7 +10,14 @@ server {
     ssl_certificate /certs/default.crt;
     ssl_certificate_key /certs/default.crt;
 
-    return 404;
+    location / {
+      return 404;
+    }
+
+    location /health {
+      add_header Content-Type text/html;
+      return 200 "healthy";
+    }
 }
 
 {{#configs}}

--- a/lib/reload-nginx.js
+++ b/lib/reload-nginx.js
@@ -2,7 +2,7 @@ import axios from "axios"
 import checksum from "checksum"
 import fs from "fs"
 import { execSync } from "child_process"
-import { find, snakeCase, trim } from "lodash"
+import { find, intersection, snakeCase, trim } from "lodash"
 
 import nginxTemplate from "./nginx-template"
 import { api as dockerCloud } from "./docker-cloud"
@@ -11,6 +11,7 @@ const { NGINX_LB_NAME: lbName, SLACK_WEBHOOK: slackWebhook } = process.env
 const configFileName = process.env.NGINX_CONFIG_FILE || "/etc/nginx/conf.d/default.conf"
 const certsPath = process.env.NGINX_CERTS || "/certs"
 const containerLimit = process.env.CONTAINER_LIMIT || "25"
+const filterNodeTags = process.env.NGINX_NODE_TAGS ? process.env.NGINX_NODE_TAGS.split(",").map(trim) : null
 
 try {
   fs.mkdirSync(certsPath)
@@ -23,6 +24,7 @@ export default function() {
   // list all containers
   dockerCloud(`/api/app/v1/container/?limit=${containerLimit}`)
     .then(fetchFullContainerDetail)
+    .then(fetchNodeTags)
     .then(getContainersToBalance)
     .then(parseServices)
     .then(generateNewConfig)
@@ -41,6 +43,18 @@ export function fetchFullContainerDetail(allContainers) {
   )
 }
 
+export function fetchNodeTags(containers) {
+  return Promise.all(
+    containers.map((container) => {
+      return dockerCloud(container.node)
+        .then((node) => {
+          container.node_tags = node.tags
+          return container
+        })
+    })
+  )
+}
+
 export function getContainersToBalance(allContainers) {
   //find containers that have an NGINX_LB env var that matches my NGINX_LB_NAME value
   return allContainers
@@ -51,6 +65,15 @@ export function getContainersToBalance(allContainers) {
     })
     //I only care about running containers
     .filter((container) => container.state === "Running")
+    //filter by NGINX_LB_NODE_TAGS if set
+    .filter((container) => {
+      if (!filterNodeTags) {
+        return true
+      }
+      const containerNodeTags = container.node_tags.map(tag => tag.name);
+      const matchingNodeTags = intersection(containerNodeTags, filterNodeTags).length
+      return matchingNodeTags === filterNodeTags.length
+    })
 }
 
 export function parseServices(services) {
@@ -111,31 +134,31 @@ export function generateNewConfig(configs) {
       if (sum !== checksum(newNginxConf)) {
         reloadNginxConfig(newNginxConf)
       } else {
-        console.log("Nginx config was unchanged");
+        console.log("Nginx config was unchanged")
       }
-    });
+    })
   }
 }
 
 export function reloadNginxConfig(config) {
-  fs.writeFileSync(configFileName, config);
-  const testCmd = process.env.NGINX_RELOAD === "false" ? "" : "nginx -t";
-  const reloadCmd = process.env.NGINX_RELOAD === "false" ? "" : "service nginx reload";
-  console.log("Testing new Nginx config...");
+  fs.writeFileSync(configFileName, config)
+  const testCmd = process.env.NGINX_RELOAD === "false" ? "" : "nginx -t"
+  const reloadCmd = process.env.NGINX_RELOAD === "false" ? "" : "service nginx reload"
+  console.log("Testing new Nginx config...")
 
   try {
-    execSync(testCmd);
-    execSync(reloadCmd);
-    console.log('Nginx reload successful');
-    console.log(config);
+    execSync(testCmd)
+    execSync(reloadCmd)
+    console.log('Nginx reload successful')
+    console.log(config)
   } catch(e) {
-    configFailed(config, e);
+    configFailed(config, e)
   }
 }
 
 export function configFailed(config, stderr) {
-  console.log("Config failed", stderr);
-  console.log(config);
+  console.log("Config failed", stderr)
+  console.log(config)
 
   if (slackWebhook) {
     const text = `Nginx (${lbName}) config failed:
@@ -145,6 +168,6 @@ export function configFailed(config, stderr) {
 \`\`\`${config}\`\`\`
     `
 
-    axios.post(slackWebhook, {text, username: `Nginx ${lbName}`});
+    axios.post(slackWebhook, {text, username: `Nginx ${lbName}`})
   }
 }


### PR DESCRIPTION
Some features that help with scaling and failover:
- add `/health` route to default server (allows services like AWS ELB to monitor health)
- add ability to filter containers by node tag with `NGINX_NODE_TAGS` env var
  - this allows a single service to scale across multiple AZ/regions, while LB's only balance containers in their own AZ/region
  - e.g. a single `web` service can deploy 20 containers across all regions, but `us-west-1` LB won't balance `us-east-1` containers.

cc @ericclemmons @EvanK 
